### PR TITLE
Portability fixes; debian arduino makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+ARDUINO_LIBS = SPI EEPROM
+BOARD_TAG    = uno
+MONITOR_PORT = /dev/ttyACM*
+# USER_LIB_PATH := $(realpath ../../libraries)
+include /usr/share/arduino/Arduino.mk

--- a/ulisp.ino
+++ b/ulisp.ino
@@ -6,6 +6,7 @@
 
 #include <setjmp.h>
 #include <SPI.h>
+#include <avr/eeprom.h>
 
 // Compile options
 

--- a/ulisp.ino
+++ b/ulisp.ino
@@ -142,8 +142,24 @@ void repl(object *env);
 void printobject (object *form);
 char *lookupbuiltin (symbol_t name);
 int lookupfn (symbol_t name);
+int lookupmin(symbol_t name);
+int lookupmax(symbol_t name);
 int builtin (char* n);
 void Display (char c);
+void error (const __FlashStringHelper *);
+void pfstring (const __FlashStringHelper *);
+void pint (int i);
+void pln ();
+void pfl ();
+void pchar (char c);
+int gchar ();
+object *apply (object *function, object *args, object **env);
+char *lookupsymbol (symbol_t name);
+void deletesymbol (symbol_t name);
+object *edit(object *fun);
+int subwidthlist (object *form, int w);
+void superprint (object *form, int lm);
+void supersub (object *form, int lm, int super);
 
 // Set up workspace
 


### PR DESCRIPTION
In order to get ulisp 1.8 to compile, I had to make a number of minor C portability fixes, such as additional forward declarations and a missing include.

Let me know if you want me to refashion this branch to remove the Makefile snippet, I realize that one is a bit iffy to push upstream.  But seems harmless for folks using the Arduino IDE (just ignored).